### PR TITLE
Add UCSBOrganization PUT endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -6,11 +6,14 @@ import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -77,5 +80,26 @@ public class UCSBOrganizationController extends ApiController {
     UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
 
     return savedOrganization;
+  }
+
+  @Operation(summary = "Update a single UCSB organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateOrganization(
+      @Parameter(name = "id") @RequestParam String id,
+      @RequestBody @Valid UCSBOrganization incoming) {
+
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+    organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    organization.setOrgTranslation(incoming.getOrgTranslation());
+    organization.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(organization);
+
+    return organization;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -101,5 +102,18 @@ public class UCSBOrganizationController extends ApiController {
     ucsbOrganizationRepository.save(organization);
 
     return organization;
+  }
+
+  @Operation(summary = "Delete a UCSB organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteOrganization(@Parameter(name = "id") @RequestParam String id) {
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+    ucsbOrganizationRepository.delete(organization);
+    return genericMessage("record %s deleted".formatted(id));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -74,6 +76,47 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 .param("orgTranslationShort", "Athletics")
                 .param("orgTranslation", "Intercollegiate Athletics")
                 .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ATHLETICS")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(incoming))
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ATHLETICS")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(incoming))
                 .with(csrf()))
         .andExpect(status().is(403));
   }
@@ -144,6 +187,86 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(get("/api/UCSBOrganization").param("id", "NOTREAL"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("NOTREAL");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOTREAL not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_update_an_existing_organization() throws Exception {
+    UCSBOrganization existingOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("SHOULD_NOT_CHANGE")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization expectedOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS"))
+        .thenReturn(Optional.of(existingOrganization));
+    when(ucsbOrganizationRepository.save(expectedOrganization)).thenReturn(expectedOrganization);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "ATHLETICS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(incoming))
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).save(expectedOrganization);
+    String expectedJson = mapper.writeValueAsString(expectedOrganization);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_update_non_existant_organization_and_gets_right_error_message()
+      throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("NOTREAL")
+            .orgTranslationShort("Not Real")
+            .orgTranslation("Not Real Organization")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("NOTREAL")).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "NOTREAL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(incoming))
+                    .with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -121,6 +123,21 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void logged_in_user_can_get_all_organizations() throws Exception {
@@ -187,6 +204,49 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(get("/api/UCSBOrganization").param("id", "NOTREAL"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("NOTREAL");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOTREAL not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_existing_organization() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS")).thenReturn(Optional.of(athletics));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).delete(any());
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("record ATHLETICS deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+      throws Exception {
+    when(ucsbOrganizationRepository.findById("NOTREAL")).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "NOTREAL").with(csrf()))
             .andExpect(status().isNotFound())
             .andReturn();
 


### PR DESCRIPTION
This PR adds the edit endpoint for `UCSBOrganization`.
The new endpoint updates an existing UCSB organization record using the values from the JSON request body.
The endpoint keeps the existing `orgCode` from the database record and updates `orgTranslationShort`, `orgTranslation`, and `inactive`.
If the requested id does not exist, the endpoint returns a 404 response with an `EntityNotFoundException` message.

Link to Deployment: https://team01-dev-powertriceps.dokku-03.cs.ucsb.edu/
Closes #17 